### PR TITLE
Made token and chat_model optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-AA_TOKEN="<your_token>"
 ALEPH_ALPHA_API_BASE="https://api.aleph-alpha.com"
-AA_CHAT_MODEL="XXX"
 USE_SEMANTIC_EMBEDDINGS=true
+
+## Optional for testing:
+# AA_TOKEN="<your_token>"
+# AA_CHAT_MODEL="XXX"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This project is a FastAPI-based wrapper for the Aleph Alpha API, providing endpo
 1. **Clone the repository:**
 
    ```bash
-   git clone <repository-url>
-   cd <repository-directory>
+   git clone git@github.com:zwischenraum/aa-api-wrapper.git
+   cd aa-api-wrapper
    ```
 
 2. **Install Poetry:**
@@ -29,18 +29,18 @@ This project is a FastAPI-based wrapper for the Aleph Alpha API, providing endpo
    ALEPH_ALPHA_API_BASE=https://api.aleph-alpha.com
    ```
 
-## Usage
+   and if you want to use semantic embeddings
 
-1. **Activate the Poetry environment:**
-
-   ```bash
-   poetry shell
    ```
+   USE_SEMANTIC_EMBEDDINGS=true
+   ```
+
+## Usage
 
 2. **Run the FastAPI server:**
 
    ```bash
-   uvicorn src.main:app --reload
+   poetry run start
    ```
 
 3. **Available Endpoints:**

--- a/src/aa_api_wrapper/settings.py
+++ b/src/aa_api_wrapper/settings.py
@@ -4,10 +4,10 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    aa_token: SecretStr = Field(alias="AA_TOKEN")
     aleph_alpha_api_base: str = Field(alias="ALEPH_ALPHA_API_BASE")
-    aa_chat_model: str = Field(alias="AA_CHAT_MODEL")
     use_semantic_embeddings: bool = Field(alias="USE_SEMANTIC_EMBEDDINGS")
+    aa_token: SecretStr | None = Field(default=None, alias="AA_TOKEN")
+    aa_chat_model: str | None = Field(default=None, alias="AA_CHAT_MODEL")
 
 
 @cache

--- a/tests/end2end_tests.py
+++ b/tests/end2end_tests.py
@@ -10,7 +10,7 @@ load_dotenv()
 settings = get_settings()
 
 openai.base_url = "http://localhost:8000/v1/"
-openai.api_key = settings.aa_token.get_secret_value()
+openai.api_key = settings.aa_token.get_secret_value() if settings.aa_token else None
 print(openai.api_key)
 
 
@@ -30,8 +30,9 @@ def test_chat_completions():
     messages: list[ChatCompletionMessageParam] = [
         {"role": "user", "content": "Hello, how are you?"}
     ]
+    model = settings.aa_chat_model if settings.aa_chat_model else None
     response = openai.chat.completions.create(
-        messages=messages, model=settings.aa_chat_model
+        messages=messages, model=model
     )
     print("Chat completions test:", response)
 


### PR DESCRIPTION
To just run the api-wrapper, the AA-token and the chat-model should not be necessary. Now they are optional. The tests crash if they are not given.